### PR TITLE
Make Tower use Enums rather than Structs

### DIFF
--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -53,6 +53,17 @@ impl<'a> Tower<'a> {
     /// of the same type are in it
     /// For example, (Your) Pawn, (Your) Pawn is disallowed
     /// but (Your) Pawn, (Enemy) Pawn is fine
+    /// ```
+    /// let player1 = Player::new_blank();
+    /// let player2 = Player::new_blank();
+    /// let pawn_gold = Piece::new(PieceCombination::PawnGold, &player1);
+    /// let pawn_silver_1 = Piece::new(PieceCombination::PawnSilver, &player1);
+    /// let pawn_silver_2 = Piece::new(PieceCombination::PawnSilver, &player2);
+    /// let bad_tower = Tower::Double(pawn_gold, pawn_silver_1);
+    /// let good_tower = Tower::Double(pawn_gold, pawn_silver_2);
+    /// assert!(!bad_tower.is_valid());
+    /// assert!(good_tower.is_valid());
+    /// ```
     pub fn is_valid(&self) -> bool {
         use pieces::Tower::*;
         match *self {

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -29,7 +29,7 @@ impl<'a> Tower<'a> {
     /// Returns a tower that has a piece added to the topmost position on this tower
     /// Returns Err if the tower is full does not modify Tower state when this happens
     /// This function does not modify the original tower.
-    pub fn drop_piece<'b>(&'b self, piece: Piece<'a>) -> Result<Tower<'a>, &'static str> {
+    pub fn drop_piece(&self, piece: Piece<'a>) -> Result<Tower<'a>, &'static str> {
         use pieces::Tower::*;
         match *self {
             Empty => Ok(Single(piece)),

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -26,7 +26,7 @@ impl<'a> Tower<'a> {
         }
     }
 
-    /// Returns a tower that has a piece added to the top most position on this tower
+    /// Returns a tower that has a piece added to the topmost position on this tower
     /// Returns Err if the tower is full does not modify Tower state when this happens
     /// This function does not modify the original tower.
     pub fn drop_piece<'b>(&'b self, piece: Piece<'a>) -> Result<Tower<'a>, &'static str> {
@@ -51,8 +51,8 @@ impl<'a> Tower<'a> {
 
     /// A tower is valid as long as no two pieces from the same player
     /// of the same type are in it
-    ///    For example, (Your) Pawn, (Your) Gold, (Your) Gold is disallowed
-    ///    but (Your) Pawn, (Your) Gold, (Enemy) Gold is fine
+    /// For example, (Your) Pawn, (Your) Pawn is disallowed
+    /// but (Your) Pawn, (Enemy) Pawn is fine
     pub fn is_valid(&self) -> bool {
         use pieces::Tower::*;
         match *self {

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -77,25 +77,11 @@ impl<'a> Tower<'a> {
             // Towers of just one piece can never have two pieces of the same type
             Single(_) => true,
             // Towers of two mustn't have the pieces be the same type and from same player
-            Double(bottom, middle) => !same_type_and_player(bottom, middle),
+            Double(bottom, middle) => bottom != middle,
             // Same idea for towers of three but it applies to all piece combinations
-            Triple(bottom, middle, top) => {
-                !(same_type_and_player(bottom, middle) || same_type_and_player(bottom, top) ||
-                      same_type_and_player(middle, top))
-            }
+            Triple(bottom, middle, top) => !(bottom == middle || bottom == top || middle == top),
         }
     }
-}
-
-/// Returns true if both pieces have the same PieceType and belong to the same player.
-pub fn same_type_and_player(piece_1: Piece, piece_2: Piece) -> bool {
-    // Compare that the *pointers* are equal, NOT the contents of the pointers
-    // This ensures that the pieces definitely belong to the same player and not just
-    // different players that happen to look like each other.
-    use std::ptr::eq;
-    let same_player = eq(piece_1.belongs_to, piece_2.belongs_to);
-    let same_type = piece_1.current_type() == piece_2.current_type();
-    return same_player && same_type;
 }
 
 /// Returns the initial number of pieces a player has at the begining of the game
@@ -149,7 +135,7 @@ pub fn initial_hand<'a>() -> Vec<PieceCombination> {
 /// to the king in chess. Note that the Commander piece has the Commander PieceType
 // for the front and back. This was done because having Option<PieceType> for just
 // a single case would be dumb.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug)]
 pub struct Piece<'a> {
     // This should be either front_side or back_side.
     // May change when piece is captured
@@ -196,6 +182,20 @@ impl<'a> Piece<'a> {
         }
     }
 }
+
+impl<'a> PartialEq for Piece<'a> {
+    fn eq(&self, other: &Piece) -> bool {
+        // Compare that the *pointers* are equal, NOT the contents of the pointers
+        // This ensures that the pieces definitely belong to the same player and not just
+        // different players that happen to look like each other.
+        use std::ptr;
+        let same_player = ptr::eq(self.belongs_to, other.belongs_to);
+        let same_type = self.current_type() == other.current_type();
+        return same_player && same_type;
+    }
+}
+
+impl<'a> Eq for Piece<'a> {}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Player<'a> {

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -5,7 +5,7 @@ pub enum Tower<'a> {
     Empty,
     Single(Piece<'a>),
     Double(Piece<'a>, Piece<'a>),
-    Triple(Piece<'a>, Piece<'a>, Piece<'a>)
+    Triple(Piece<'a>, Piece<'a>, Piece<'a>),
 }
 
 /// A convient enum for refering to the height of a tower.
@@ -27,7 +27,7 @@ impl<'a> Tower<'a> {
             Empty => Err("Cannot lift a piece off an empty tower!"),
             Single(bottom) => Ok((Empty, bottom)),
             Double(bottom, middle) => Ok((Single(bottom), middle)),
-            Triple(bottom, middle, top) => Ok((Double(bottom, middle), top))
+            Triple(bottom, middle, top) => Ok((Double(bottom, middle), top)),
         }
     }
 
@@ -50,7 +50,7 @@ impl<'a> Tower<'a> {
             Empty => TowerHeight::Empty,
             Single(_) => TowerHeight::Bottom,
             Double(_, _) => TowerHeight::Middle,
-            Triple(_, _, _) => TowerHeight::Top
+            Triple(_, _, _) => TowerHeight::Top,
         }
     }
 
@@ -59,8 +59,8 @@ impl<'a> Tower<'a> {
     /// For example, (Your) Pawn, (Your) Pawn is disallowed
     /// but (Your) Pawn, (Enemy) Pawn is fine
     /// ```
-    /// let player1 = Player::new_blank();
-    /// let player2 = Player::new_blank();
+    /// # let player1 = Player::new_blank();
+    /// # let player2 = Player::new_blank();
     /// let pawn_gold = Piece::new(PieceCombination::PawnGold, &player1);
     /// let pawn_silver_1 = Piece::new(PieceCombination::PawnSilver, &player1);
     /// let pawn_silver_2 = Piece::new(PieceCombination::PawnSilver, &player2);
@@ -79,9 +79,10 @@ impl<'a> Tower<'a> {
             // Towers of two mustn't have the pieces be the same type and from same player
             Double(bottom, middle) => !same_type_and_player(bottom, middle),
             // Same idea for towers of three but it applies to all piece combinations
-            Triple(bottom, middle, top) => !(same_type_and_player(bottom, middle) ||
-                                             same_type_and_player(bottom, top)    || 
-                                             same_type_and_player(middle, top))
+            Triple(bottom, middle, top) => {
+                !(same_type_and_player(bottom, middle) || same_type_and_player(bottom, top) ||
+                      same_type_and_player(middle, top))
+            }
         }
     }
 }
@@ -114,30 +115,31 @@ pub fn same_type_and_player(piece_1: Piece, piece_2: Piece) -> bool {
 pub fn initial_hand<'a>() -> Vec<PieceCombination> {
     use PieceCombination::*;
     // There are probably better ways of doing this but I am lazy and do not care
-    let vec = [Commander,
-               CaptainPistol,
-               CaptainPistol,
-               SamuraiPike,
-               SamuraiPike,
-               SpyCladestinite,
-               SpyCladestinite,
-               SpyCladestinite,
-               CatapultLance,
-               FortressLance,
-               HiddenDragonKing,
-               ProdigyPhoenix,
-               BowArrow,
-               BowArrow,
-               PawnBronze,
-               PawnBronze,
-               PawnBronze,
-               PawnBronze,
-               PawnBronze,
-               PawnBronze,
-               PawnBronze,
-               PawnSilver,
-               PawnGold]
-        .to_vec();
+    let vec = [
+        Commander,
+        CaptainPistol,
+        CaptainPistol,
+        SamuraiPike,
+        SamuraiPike,
+        SpyCladestinite,
+        SpyCladestinite,
+        SpyCladestinite,
+        CatapultLance,
+        FortressLance,
+        HiddenDragonKing,
+        ProdigyPhoenix,
+        BowArrow,
+        BowArrow,
+        PawnBronze,
+        PawnBronze,
+        PawnBronze,
+        PawnBronze,
+        PawnBronze,
+        PawnBronze,
+        PawnBronze,
+        PawnSilver,
+        PawnGold,
+    ].to_vec();
     return vec;
 }
 

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -16,10 +16,10 @@ impl<'a> Tower<'a> {
     /// Returns the top most piece and a tower that has its top piece removed
     /// Returns Err if the tower is empty
     /// This function does not modify the original tower
-    pub fn pop(&self) -> Result<(Tower, Piece<'a>), &'static str> {
+    pub fn lift_piece(&self) -> Result<(Tower, Piece<'a>), &'static str> {
         use pieces::Tower::*;
         match *self {
-            Empty => Err("Cannot pop an empty tower!"),
+            Empty => Err("Cannot lift a piece off an empty tower!"),
             Single(bottom) => Ok((Empty, bottom)),
             Double(bottom, middle) => Ok((Single(bottom), middle)),
             Triple(bottom, middle, top) => Ok((Double(bottom, middle), top))

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -29,46 +29,47 @@ impl<'a> Tower<'a> {
             Empty => None,
         }
     }
-    // Set the given position to the given piece
-    // Panics on invalid tower setting or when trying to set a piece to the Empty height
-    fn set(&mut self, piece: Option<Piece<'a>>, position: TowerHeight) {
+    // Sets the appropriate piece to the one specified
+    // Returns Err when trying to set the Empty position
+    // (does not modify Tower state when this happens).
+    // NOTE: This function does not check if the resulting tower is,
+    // in fact, valid. This may useful if you need to alter a tower arbitrarily.
+    fn set(&mut self, piece: Option<Piece<'a>>, position: TowerHeight) -> Result<Tower, &'static str> {
         use pieces::TowerHeight::*;
         match position {
-            Top => self.top = piece,
-            Middle => self.mid = piece,
-            Bottom => self.bottom = piece,
-            Empty => panic!("Cannot set a piece at TowerHeight::Empty")
-        }
-
-        if !self.is_valid() {
-            panic!("Attempt to set Tower to an invalid state: {:?}", self);
+            Empty => Err("Cannot set a piece at TowerHeight::Empty"),
+            Top => {self.top = piece; return Ok(*self)}
+            Middle => {self.mid = piece; return Ok(*self)},
+            Bottom => {self.bottom = piece; return Ok(*self)},
+            
         }
     }
 
     /// Removes and returns the top most piece from the tower
-    /// Panics if the tower is empty
-    pub fn pop(&mut self) -> Piece<'a> {
+    /// Returns Err if the tower is empty (does not modify Tower
+    /// state when this happense).
+    pub fn pop(&mut self) -> Result<Piece<'a>, &'static str> {
         let height = self.height();
 
         if height == TowerHeight::Empty {
-            panic!("Cannot pop an empty tower!")
+            return Err("Cannot pop an empty tower!");
         }
         // This unwrap is safe because the tower is non-empty
         let top_piece = self.get(height).unwrap();
-        self.set(None, height);
-        return top_piece
+        self.set(None, height).unwrap();
+        return Ok(top_piece)
     }
 
     /// Adds a piece to the top most position on the tower
-    /// Panics if the tower is full
-    pub fn drop_piece(&mut self, piece: Piece<'a>) {
+    /// Returns Err if the tower is full does not modify Tower state when this happens
+    pub fn drop_piece(&mut self, piece: Piece<'a>) -> Result<Tower, &'static str> {
         let height = self.height();
         use pieces::TowerHeight::*;
         match height {
-            Top => panic!("Tower is full."),
+            Top => Err("Tower is full."),
             Middle => self.set(Some(piece), Top),
             Bottom => self.set(Some(piece), Middle),
-            Empty =>self.set(Some(piece), Bottom),
+            Empty => self.set(Some(piece), Bottom),
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pop() {
+    fn test_lift_piece() {
         let player = Player::new_blank();
         let piece_bottom = Piece::new(PieceCombination::PawnGold, &player);
         let piece_middle = Piece::new(PieceCombination::BowArrow, &player);
@@ -156,20 +156,20 @@ mod tests {
 
         let mut tower = Tower::Triple(piece_bottom, piece_middle, piece_top);
 
-        let (tower, piece_top_pop) = tower.pop().unwrap();
-        assert_eq!(piece_top_pop, piece_top);
+        let (tower, piece_top_lift_piece) = tower.lift_piece().unwrap();
+        assert_eq!(piece_top_lift_piece, piece_top);
         assert_eq!(tower.height(), TowerHeight::Middle);
 
-        let (tower, piece_middle_pop) = tower.pop().unwrap();
-        assert_eq!(piece_middle_pop, piece_middle);
+        let (tower, piece_middle_lift_piece) = tower.lift_piece().unwrap();
+        assert_eq!(piece_middle_lift_piece, piece_middle);
         assert_eq!(tower.height(), TowerHeight::Bottom);
         
-        let (tower, piece_bottom_pop) = tower.pop().unwrap();
-        assert_eq!(piece_bottom_pop, piece_bottom);
+        let (tower, piece_bottom_lift_piece) = tower.lift_piece().unwrap();
+        assert_eq!(piece_bottom_lift_piece, piece_bottom);
         assert_eq!(tower.height(), TowerHeight::Empty);  
 
         let mut empty = Tower::Empty;
-        assert!(empty.pop().is_err());
+        assert!(empty.lift_piece().is_err());
     }
 
     #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -161,13 +161,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_panic_on_empty_pop() {
-        let mut empty = Tower::new(None, None, None).unwrap();
-        empty.pop();
-    }
-
-    #[test]
     fn test_pop() {
         let player = Player::new_blank();
         let piece_bottom = Piece::new(PieceCombination::PawnGold, &player);
@@ -177,30 +170,19 @@ mod tests {
         let mut tower = Tower::new(Some(piece_bottom), Some(piece_middle), Some(piece_top)).unwrap();
 
         let piece_top_pop = tower.pop();
-        assert_eq!(piece_top_pop, piece_top);
+        assert_eq!(piece_top_pop.unwrap(), piece_top);
         assert_eq!(tower.height(), TowerHeight::Middle);
 
         let piece_middle_pop = tower.pop();
-        assert_eq!(piece_middle_pop, piece_middle);
+        assert_eq!(piece_middle_pop.unwrap(), piece_middle);
         assert_eq!(tower.height(), TowerHeight::Bottom);
         
         let piece_bottom_pop = tower.pop();
-        assert_eq!(piece_bottom_pop, piece_bottom);
-        assert_eq!(tower.height(), TowerHeight::Empty);   
-    }
+        assert_eq!(piece_bottom_pop.unwrap(), piece_bottom);
+        assert_eq!(tower.height(), TowerHeight::Empty);  
 
-    #[test]
-    #[should_panic]
-    fn test_panic_on_full_drop() {
-        let player = Player::new_blank();
-        let piece_bottom = Piece::new(PieceCombination::PawnGold, &player);
-        let piece_middle = Piece::new(PieceCombination::BowArrow, &player);
-        let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, &player);
-
-        let piece = Piece::new(PieceCombination::Commander, &player);
-
-        let mut full = Tower::new(Some(piece_bottom), Some(piece_middle), Some(piece_top)).unwrap();
-        full.drop_piece(piece);
+        let mut empty = Tower::new(None, None, None).unwrap();
+        assert!(empty.pop().is_err()); 
     }
 
     #[test]
@@ -224,5 +206,10 @@ mod tests {
         tower.drop_piece(piece_top);
         assert_eq!(tower.height(), Top);
         assert_eq!(tower.get(Top), Some(piece_top));
+
+
+        let piece = Piece::new(PieceCombination::Commander, &player);
+        let mut full = Tower::new(Some(piece_bottom), Some(piece_middle), Some(piece_top)).unwrap();
+        assert!(full.drop_piece(piece).is_err());
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -182,7 +182,9 @@ mod tests {
         assert_eq!(tower.height(), TowerHeight::Empty);  
 
         let mut empty = Tower::new(None, None, None).unwrap();
-        assert!(empty.pop().is_err()); 
+        let mut clone = empty.clone();
+        assert!(empty.pop().is_err());
+        assert_eq!(empty, clone, "Original was {:?} but is now {:?}", clone, empty);
     }
 
     #[test]
@@ -210,6 +212,8 @@ mod tests {
 
         let piece = Piece::new(PieceCombination::Commander, &player);
         let mut full = Tower::new(Some(piece_bottom), Some(piece_middle), Some(piece_top)).unwrap();
+        let mut clone = full.clone();
         assert!(full.drop_piece(piece).is_err());
+        assert_eq!(full, clone, "Original was {:?} but is now {:?}", clone, full);
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 
     #[test]
-    fn test_same_type_and_player() {
+    fn test_piece_eq() {
         let player1 = Player::new_blank();
         let player2 = Player::new_blank();
 
@@ -71,7 +71,7 @@ mod tests {
             belongs_to: &player1,
         };
         assert!(
-            same_type_and_player(piece_1, piece_2),
+            piece_1 == piece_2,
             "Expected the types to be the same even though the current sides are different."
         );
 
@@ -90,7 +90,7 @@ mod tests {
             belongs_to: &player1,
         };
         assert!(
-            !same_type_and_player(piece_3, piece_4),
+            piece_3 != piece_4,
             "Expected the types to be different even though the sides are the same"
         );
 
@@ -109,7 +109,7 @@ mod tests {
             belongs_to: &player2,
         };
         assert!(
-            !same_type_and_player(piece_5, piece_6),
+            piece_5 != piece_6,
             "Expected the players to be different even though the sides and type are the same"
         );
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -48,7 +48,7 @@ mod tests {
         assert!(!double_same_tower.is_valid());
 
         let triple_same_tower = Tower::Triple(pawn_gold, pawn_silver, pawn_gold_2);
-        assert!(!triple_same_tower.is_valid());       
+        assert!(!triple_same_tower.is_valid());
     }
 
     #[test]
@@ -70,8 +70,10 @@ mod tests {
             back_side: PieceType::Pawn,
             belongs_to: &player1,
         };
-        assert!(same_type_and_player(piece_1, piece_2),
-                "Expected the types to be the same even though the current sides are different.");
+        assert!(
+            same_type_and_player(piece_1, piece_2),
+            "Expected the types to be the same even though the current sides are different."
+        );
 
         // Same pieces but different current sides (false)
         let piece_3 = Piece {
@@ -87,8 +89,10 @@ mod tests {
             back_side: PieceType::Gold,
             belongs_to: &player1,
         };
-        assert!(!same_type_and_player(piece_3, piece_4),
-                "Expected the types to be different even though the sides are the same");
+        assert!(
+            !same_type_and_player(piece_3, piece_4),
+            "Expected the types to be different even though the sides are the same"
+        );
 
         // Same piece types but different players (false)
         let piece_5 = Piece {
@@ -104,8 +108,10 @@ mod tests {
             back_side: PieceType::Gold,
             belongs_to: &player2,
         };
-        assert!(!same_type_and_player(piece_5, piece_6),
-                "Expected the players to be different even though the sides and type are the same");
+        assert!(
+            !same_type_and_player(piece_5, piece_6),
+            "Expected the players to be different even though the sides and type are the same"
+        );
     }
 
     #[test]
@@ -163,10 +169,10 @@ mod tests {
         let (tower, piece_middle_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_middle_lift_piece, piece_middle);
         assert_eq!(tower.height(), TowerHeight::Bottom);
-        
+
         let (tower, piece_bottom_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_bottom_lift_piece, piece_bottom);
-        assert_eq!(tower.height(), TowerHeight::Empty);  
+        assert_eq!(tower.height(), TowerHeight::Empty);
 
         let mut empty = Tower::Empty;
         assert!(empty.lift_piece().is_err());
@@ -189,7 +195,7 @@ mod tests {
         tower = tower.drop_piece(piece_middle).unwrap();
         assert_eq!(tower.height(), Middle);
         assert_eq!(tower, Tower::Double(piece_bottom, piece_middle));
-        
+
         tower = tower.drop_piece(piece_top).unwrap();
         assert_eq!(tower.height(), Top);
         assert_eq!(tower, Tower::Triple(piece_bottom, piece_middle, piece_top));


### PR DESCRIPTION
Fixes #1, #2 

The rationale for using Enums instead of Structs was that three fields for a Struct made it hard to tell the state of the tower at any given time, and allowed for many variations of "bad towers" where the bottom or middle slots would have holes in them. We could solve this issue by using a vector or fixed size array, however, there are only four possible states a tower can be in: Empty, One Piece ([no relation](https://en.wikipedia.org/wiki/One_Piece)), Two Pieces, or Three Pieces.  Thus, an Enum seems most appropriate to use here. This also makes the problem of having to unwrap every field not an issue, as these Enums simply take `Piece`, not `Option<Piece>`

Additionally, using Enums makes implementing `drop_piece` and `lift_piece` a lot simpler.