### PR TITLE
Make Pieces take a Color rather than a pointer to a Player

### DIFF
--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -20,7 +20,6 @@ pub enum TowerHeight {
 impl Tower {
     /// Returns the top most piece and a tower that has its top piece removed
     /// Returns Err if the tower is empty
-    /// This function does not modify the original tower
     pub fn lift_piece(&self) -> Result<(Tower, Piece), &'static str> {
         use pieces::Tower::*;
         match *self {
@@ -33,7 +32,6 @@ impl Tower {
 
     /// Returns a tower that has a piece added to the topmost position on this tower
     /// Returns Err if the tower is full does not modify Tower state when this happens
-    /// This function does not modify the original tower.
     pub fn drop_piece(&self, piece: Piece) -> Result<Tower, &'static str> {
         use pieces::Tower::*;
         match *self {
@@ -101,7 +99,7 @@ impl Tower {
 pub fn initial_hand() -> Vec<PieceCombination> {
     use PieceCombination::*;
     // There are probably better ways of doing this but I am lazy and do not care
-    let vec = [
+    let vec = vec![
         Commander,
         CaptainPistol,
         CaptainPistol,
@@ -125,8 +123,8 @@ pub fn initial_hand() -> Vec<PieceCombination> {
         PawnBronze,
         PawnSilver,
         PawnGold,
-    ].to_vec();
-    return vec;
+    ];
+    vec
 }
 
 /// A piece has two sides, called "Front" and "Back." Pieces initially
@@ -185,7 +183,7 @@ impl PartialEq for Piece {
     fn eq(&self, other: &Piece) -> bool {
         let same_player = self.color == other.color;
         let same_type = self.current_type() == other.current_type();
-        return same_player && same_type;
+        same_player && same_type
     }
 }
 
@@ -207,7 +205,7 @@ pub enum Color {
 impl Player {
     // Stub for the Player struct
     pub fn new_blank() -> Player {
-        return Player { hand: vec![] };
+        Player { hand: vec![] }
     }
 }
 

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -1,11 +1,11 @@
 /// A tower consists of zero to three pieces. Towers may contain pieces from
 /// both players. Only the top piece on a tower can move.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Tower<'a> {
+pub enum Tower {
     Empty,
-    Single(Piece<'a>),
-    Double(Piece<'a>, Piece<'a>),
-    Triple(Piece<'a>, Piece<'a>, Piece<'a>),
+    Single(Piece),
+    Double(Piece, Piece),
+    Triple(Piece, Piece, Piece),
 }
 
 /// A convient enum for refering to the height of a tower.
@@ -17,11 +17,11 @@ pub enum TowerHeight {
     Empty,
 }
 
-impl<'a> Tower<'a> {
+impl Tower {
     /// Returns the top most piece and a tower that has its top piece removed
     /// Returns Err if the tower is empty
     /// This function does not modify the original tower
-    pub fn lift_piece(&self) -> Result<(Tower, Piece<'a>), &'static str> {
+    pub fn lift_piece(&self) -> Result<(Tower, Piece), &'static str> {
         use pieces::Tower::*;
         match *self {
             Empty => Err("Cannot lift a piece off an empty tower!"),
@@ -34,7 +34,7 @@ impl<'a> Tower<'a> {
     /// Returns a tower that has a piece added to the topmost position on this tower
     /// Returns Err if the tower is full does not modify Tower state when this happens
     /// This function does not modify the original tower.
-    pub fn drop_piece(&self, piece: Piece<'a>) -> Result<Tower<'a>, &'static str> {
+    pub fn drop_piece(&self, piece: Piece) -> Result<Tower, &'static str> {
         use pieces::Tower::*;
         match *self {
             Empty => Ok(Single(piece)),
@@ -136,19 +136,17 @@ pub fn initial_hand<'a>() -> Vec<PieceCombination> {
 // for the front and back. This was done because having Option<PieceType> for just
 // a single case would be dumb.
 #[derive(Clone, Copy, Debug)]
-pub struct Piece<'a> {
+pub struct Piece {
     // This should be either front_side or back_side.
     // May change when piece is captured
     pub current_side: SideType,
     pub front_side: PieceType,
     pub back_side: PieceType,
-    // We use a pointer here because the player owns the piece, not
-    // the other way around.
-    pub belongs_to: &'a Player<'a>,
+    pub color: Color,
 }
 
-impl<'a> Piece<'a> {
-    pub fn new(piece_combination: PieceCombination, player: &'a Player) -> Piece<'a> {
+impl Piece {
+    pub fn new(piece_combination: PieceCombination, color: Color) -> Piece {
         use pieces::PieceType::*;
         use pieces::PieceCombination::*;
         let (front_side, back_side) = match piece_combination {
@@ -170,7 +168,7 @@ impl<'a> Piece<'a> {
             current_side: SideType::Front,
             front_side: front_side,
             back_side: back_side,
-            belongs_to: player,
+            color: color,
         };
     }
 
@@ -183,28 +181,32 @@ impl<'a> Piece<'a> {
     }
 }
 
-impl<'a> PartialEq for Piece<'a> {
+impl PartialEq for Piece {
     fn eq(&self, other: &Piece) -> bool {
-        // Compare that the *pointers* are equal, NOT the contents of the pointers
-        // This ensures that the pieces definitely belong to the same player and not just
-        // different players that happen to look like each other.
-        use std::ptr;
-        let same_player = ptr::eq(self.belongs_to, other.belongs_to);
+        let same_player = self.color == other.color;
         let same_type = self.current_type() == other.current_type();
         return same_player && same_type;
     }
 }
 
-impl<'a> Eq for Piece<'a> {}
+impl<'a> Eq for Piece {}
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct Player<'a> {
-    pub hand: Vec<Piece<'a>>,
+pub struct Player {
+    pub hand: Vec<Piece>,
 }
 
-impl<'a> Player<'a> {
+/// The color of a piece determines which player owns the piece
+/// Note that Black always moves first
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Color {
+    Black,
+    White,
+}
+
+impl<'a> Player {
     // Stub for the Player struct
-    pub fn new_blank() -> Player<'a> {
+    pub fn new_blank() -> Player {
         return Player { hand: vec![] };
     }
 }

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -99,7 +99,7 @@ impl Tower {
 pub fn initial_hand() -> Vec<PieceCombination> {
     use PieceCombination::*;
     // There are probably better ways of doing this but I am lazy and do not care
-    let vec = vec![
+    vec![
         Commander,
         CaptainPistol,
         CaptainPistol,
@@ -123,8 +123,7 @@ pub fn initial_hand() -> Vec<PieceCombination> {
         PawnBronze,
         PawnSilver,
         PawnGold,
-    ];
-    vec
+    ]
 }
 
 /// A piece has two sides, called "Front" and "Back." Pieces initially

--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -98,7 +98,7 @@ impl Tower {
 /// PawnBronze       x7
 /// PawnSilver       x1
 /// PawnGold         x1
-pub fn initial_hand<'a>() -> Vec<PieceCombination> {
+pub fn initial_hand() -> Vec<PieceCombination> {
     use PieceCombination::*;
     // There are probably better ways of doing this but I am lazy and do not care
     let vec = [
@@ -189,7 +189,7 @@ impl PartialEq for Piece {
     }
 }
 
-impl<'a> Eq for Piece {}
+impl Eq for Piece {}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Player {
@@ -204,7 +204,7 @@ pub enum Color {
     White,
 }
 
-impl<'a> Player {
+impl Player {
     // Stub for the Player struct
     pub fn new_blank() -> Player {
         return Player { hand: vec![] };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,19 +4,18 @@ mod tests {
 
     #[test]
     fn test_commander_has_both_front_and_back() {
-        let player = Player::new_blank();
-        let commander = Piece::new(PieceCombination::Commander, &player);
+        let commander = Piece::new(PieceCombination::Commander, Color::Black);
         assert_eq!(commander.front_side, PieceType::Commander);
         assert_eq!(commander.back_side, PieceType::Commander);
     }
 
     #[test]
     fn test_valid_towers() {
-        let player1 = Player::new_blank();
-        let player2 = Player::new_blank();
-        let pawn_gold = Piece::new(PieceCombination::PawnGold, &player1);
-        let bow_arrow = Piece::new(PieceCombination::BowArrow, &player1);
-        let pawn_gold_2 = Piece::new(PieceCombination::PawnGold, &player2);
+        let black = Color::Black;
+        let white = Color::White;
+        let pawn_gold = Piece::new(PieceCombination::PawnGold, black);
+        let bow_arrow = Piece::new(PieceCombination::BowArrow, black);
+        let pawn_gold_2 = Piece::new(PieceCombination::PawnGold, white);
 
         let empty_tower = Tower::Empty;
         assert!(empty_tower.is_valid());
@@ -36,12 +35,12 @@ mod tests {
 
     #[test]
     fn test_invalid_towers() {
-        let player1 = Player::new_blank();
-        let player2 = Player::new_blank();
-        let pawn_gold = Piece::new(PieceCombination::PawnGold, &player1);
-        let pawn_silver = Piece::new(PieceCombination::PawnSilver, &player1);
-        let bow_arrow = Piece::new(PieceCombination::BowArrow, &player1);
-        let pawn_gold_2 = Piece::new(PieceCombination::PawnGold, &player2);
+        let black = Color::Black;
+        let white = Color::White;
+        let pawn_gold = Piece::new(PieceCombination::PawnGold, black);
+        let pawn_silver = Piece::new(PieceCombination::PawnSilver, black);
+        let bow_arrow = Piece::new(PieceCombination::BowArrow, black);
+        let pawn_gold_2 = Piece::new(PieceCombination::PawnGold, white);
 
         // Towers can't have two of the same piece in them
         let double_same_tower = Tower::Double(pawn_gold, pawn_silver);
@@ -53,22 +52,22 @@ mod tests {
 
     #[test]
     fn test_piece_eq() {
-        let player1 = Player::new_blank();
-        let player2 = Player::new_blank();
+        let black = Color::Black;
+        let white = Color::White;
 
         // Same piece types but one is on the back (true)
         let piece_1 = Piece {
             current_side: SideType::Front,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &player1,
+            color: black,
         };
 
         let piece_2 = Piece {
             current_side: SideType::Back,
             front_side: PieceType::Silver,
             back_side: PieceType::Pawn,
-            belongs_to: &player1,
+            color: black,
         };
         assert!(
             piece_1 == piece_2,
@@ -80,14 +79,14 @@ mod tests {
             current_side: SideType::Front,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &player1,
+            color: black,
         };
 
         let piece_4 = Piece {
             current_side: SideType::Back,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &player1,
+            color: black,
         };
         assert!(
             piece_3 != piece_4,
@@ -99,14 +98,14 @@ mod tests {
             current_side: SideType::Front,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &player1,
+            color: black,
         };
 
         let piece_6 = Piece {
             current_side: SideType::Front,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &player2,
+            color: white,
         };
         assert!(
             piece_5 != piece_6,
@@ -120,7 +119,7 @@ mod tests {
             current_side: SideType::Front,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &Player::new_blank(),
+            color: Color::Black,
         };
         assert_eq!(PieceType::Pawn, front_piece.current_type());
 
@@ -128,17 +127,17 @@ mod tests {
             current_side: SideType::Back,
             front_side: PieceType::Pawn,
             back_side: PieceType::Gold,
-            belongs_to: &Player::new_blank(),
+            color: Color::Black,
         };
         assert_eq!(PieceType::Gold, back_piece.current_type());
     }
 
     #[test]
     fn test_height() {
-        let player = Player::new_blank();
-        let piece_1 = Piece::new(PieceCombination::PawnGold, &player);
-        let piece_2 = Piece::new(PieceCombination::BowArrow, &player);
-        let piece_3 = Piece::new(PieceCombination::ProdigyPhoenix, &player);
+        let player = Color::Black;
+        let piece_1 = Piece::new(PieceCombination::PawnGold, player);
+        let piece_2 = Piece::new(PieceCombination::BowArrow, player);
+        let piece_3 = Piece::new(PieceCombination::ProdigyPhoenix, player);
 
         let empty = Tower::Empty;
         assert_eq!(empty.height(), TowerHeight::Empty);
@@ -155,10 +154,10 @@ mod tests {
 
     #[test]
     fn test_lift_piece() {
-        let player = Player::new_blank();
-        let piece_bottom = Piece::new(PieceCombination::PawnGold, &player);
-        let piece_middle = Piece::new(PieceCombination::BowArrow, &player);
-        let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, &player);
+        let player = Color::Black;
+        let piece_bottom = Piece::new(PieceCombination::PawnGold, player);
+        let piece_middle = Piece::new(PieceCombination::BowArrow, player);
+        let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, player);
 
         let mut tower = Tower::Triple(piece_bottom, piece_middle, piece_top);
 
@@ -181,10 +180,10 @@ mod tests {
     #[test]
     fn test_drop() {
         use pieces::TowerHeight::*;
-        let player = Player::new_blank();
-        let piece_bottom = Piece::new(PieceCombination::PawnGold, &player);
-        let piece_middle = Piece::new(PieceCombination::BowArrow, &player);
-        let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, &player);
+        let player = Color::Black;
+        let piece_bottom = Piece::new(PieceCombination::PawnGold, player);
+        let piece_middle = Piece::new(PieceCombination::BowArrow, player);
+        let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, player);
 
         let mut tower = Tower::Empty;
 
@@ -200,7 +199,7 @@ mod tests {
         assert_eq!(tower.height(), Top);
         assert_eq!(tower, Tower::Triple(piece_bottom, piece_middle, piece_top));
 
-        let piece = Piece::new(PieceCombination::Commander, &player);
+        let piece = Piece::new(PieceCombination::Commander, player);
         let mut full = Tower::Triple(piece_bottom, piece_middle, piece_top);
         assert!(full.drop_piece(piece).is_err());
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,6 @@ mod tests {
         let white = Color::White;
         let pawn_gold = Piece::new(PieceCombination::PawnGold, black);
         let pawn_silver = Piece::new(PieceCombination::PawnSilver, black);
-        let bow_arrow = Piece::new(PieceCombination::BowArrow, black);
         let pawn_gold_2 = Piece::new(PieceCombination::PawnGold, white);
 
         // Towers can't have two of the same piece in them
@@ -159,7 +158,7 @@ mod tests {
         let piece_middle = Piece::new(PieceCombination::BowArrow, player);
         let piece_top = Piece::new(PieceCombination::ProdigyPhoenix, player);
 
-        let mut tower = Tower::Triple(piece_bottom, piece_middle, piece_top);
+        let tower = Tower::Triple(piece_bottom, piece_middle, piece_top);
 
         let (tower, piece_top_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_top_lift_piece, piece_top);
@@ -173,7 +172,7 @@ mod tests {
         assert_eq!(piece_bottom_lift_piece, piece_bottom);
         assert_eq!(tower.height(), TowerHeight::Empty);
 
-        let mut empty = Tower::Empty;
+        let empty = Tower::Empty;
         assert!(empty.lift_piece().is_err());
     }
 
@@ -200,7 +199,7 @@ mod tests {
         assert_eq!(tower, Tower::Triple(piece_bottom, piece_middle, piece_top));
 
         let piece = Piece::new(PieceCombination::Commander, player);
-        let mut full = Tower::Triple(piece_bottom, piece_middle, piece_top);
+        let full = Tower::Triple(piece_bottom, piece_middle, piece_top);
         assert!(full.drop_piece(piece).is_err());
     }
 }


### PR DESCRIPTION
Fixes #8

Having pieces constantly borrow the player would likely be very cumbersome in the future.
Since piece color doesn't change anyways and a piece has effectively no reason to access
any of the fields in Player, we use a Color instead to represent which players has that piece.

This also has added benefit that changing who owns the piece is extremely easy
(just change color from Color::Black to Color::White or vice versa).