### PR TITLE
Fix PawnGold not creating the correct piece.

### DIFF
--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -163,7 +163,7 @@ impl<'a> Piece<'a> {
             BowArrow => (Bow, Arrow),
             PawnBronze => (Pawn, Bronze),
             PawnSilver => (Pawn, Silver),
-            PawnGold => (Pawn, Bronze),
+            PawnGold => (Pawn, Gold),
         };
 
         return Piece {


### PR DESCRIPTION
Now it does what it actually says it does.

Fixes #12 