### PR TITLE
Remove TowerHeight enum and `height` function.

### DIFF
--- a/src/pieces.rs
+++ b/src/pieces.rs
@@ -8,15 +8,6 @@ pub enum Tower {
     Triple(Piece, Piece, Piece),
 }
 
-/// A convient enum for refering to the height of a tower.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TowerHeight {
-    Top,
-    Middle,
-    Bottom,
-    Empty,
-}
-
 impl Tower {
     /// Returns the top most piece and a tower that has its top piece removed
     /// Returns Err if the tower is empty
@@ -39,16 +30,6 @@ impl Tower {
             Single(bottom) => Ok(Double(bottom, piece)),
             Double(bottom, middle) => Ok(Triple(bottom, middle, piece)),
             Triple(_, _, _) => Err("Tower is full."),
-        }
-    }
-
-    pub fn height(&self) -> TowerHeight {
-        use pieces::Tower::*;
-        match *self {
-            Empty => TowerHeight::Empty,
-            Single(_) => TowerHeight::Bottom,
-            Double(_, _) => TowerHeight::Middle,
-            Triple(_, _, _) => TowerHeight::Top,
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -132,26 +132,6 @@ mod tests {
     }
 
     #[test]
-    fn test_height() {
-        let player = Color::Black;
-        let piece_1 = Piece::new(PieceCombination::PawnGold, player);
-        let piece_2 = Piece::new(PieceCombination::BowArrow, player);
-        let piece_3 = Piece::new(PieceCombination::ProdigyPhoenix, player);
-
-        let empty = Tower::Empty;
-        assert_eq!(empty.height(), TowerHeight::Empty);
-
-        let bottom = Tower::Single(piece_1);
-        assert_eq!(bottom.height(), TowerHeight::Bottom);
-
-        let middle = Tower::Double(piece_1, piece_2);
-        assert_eq!(middle.height(), TowerHeight::Middle);
-
-        let top = Tower::Triple(piece_1, piece_2, piece_3);
-        assert_eq!(top.height(), TowerHeight::Top);
-    }
-
-    #[test]
     fn test_lift_piece() {
         let player = Color::Black;
         let piece_bottom = Piece::new(PieceCombination::PawnGold, player);
@@ -162,15 +142,15 @@ mod tests {
 
         let (tower, piece_top_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_top_lift_piece, piece_top);
-        assert_eq!(tower.height(), TowerHeight::Middle);
+        assert_eq!(tower, Tower::Double(piece_bottom, piece_middle));
 
         let (tower, piece_middle_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_middle_lift_piece, piece_middle);
-        assert_eq!(tower.height(), TowerHeight::Bottom);
+        assert_eq!(tower, Tower::Single(piece_bottom));
 
         let (tower, piece_bottom_lift_piece) = tower.lift_piece().unwrap();
         assert_eq!(piece_bottom_lift_piece, piece_bottom);
-        assert_eq!(tower.height(), TowerHeight::Empty);
+        assert_eq!(tower, Tower::Empty);
 
         let empty = Tower::Empty;
         assert!(empty.lift_piece().is_err());
@@ -178,7 +158,6 @@ mod tests {
 
     #[test]
     fn test_drop() {
-        use pieces::TowerHeight::*;
         let player = Color::Black;
         let piece_bottom = Piece::new(PieceCombination::PawnGold, player);
         let piece_middle = Piece::new(PieceCombination::BowArrow, player);
@@ -187,15 +166,12 @@ mod tests {
         let mut tower = Tower::Empty;
 
         tower = tower.drop_piece(piece_bottom).unwrap();
-        assert_eq!(tower.height(), Bottom);
         assert_eq!(tower, Tower::Single(piece_bottom));
 
         tower = tower.drop_piece(piece_middle).unwrap();
-        assert_eq!(tower.height(), Middle);
         assert_eq!(tower, Tower::Double(piece_bottom, piece_middle));
 
         tower = tower.drop_piece(piece_top).unwrap();
-        assert_eq!(tower.height(), Top);
         assert_eq!(tower, Tower::Triple(piece_bottom, piece_middle, piece_top));
 
         let piece = Piece::new(PieceCombination::Commander, player);


### PR DESCRIPTION
Since Tower is now an Enum of the four different possible tower heights, TowerHeight is no longer nessecary as one can simply match on the tower itself to get the height. Thus, `height` has also been removed.